### PR TITLE
Replacing ROOT_PATH with __DIR__ directory

### DIFF
--- a/src/Mouf/Html/HtmlElement/HtmlFromFile.php
+++ b/src/Mouf/Html/HtmlElement/HtmlFromFile.php
@@ -62,7 +62,7 @@ class HtmlFromFile implements HtmlElementInterface {
 		}
 
 		if ($isRelative && $this->relativeToRootPath) {
-			$fileName = ROOT_PATH.$this->fileName;
+			$fileName = __DIR__.'/../../../../../../../'.$this->fileName;
 		} else {
 			$fileName = $this->fileName;
 		}
@@ -74,4 +74,3 @@ class HtmlFromFile implements HtmlElementInterface {
 		}
 	}
 }
-?>


### PR DESCRIPTION
This is needed to make the package framework agnostic